### PR TITLE
Resolved the error of \home\user\app path not found

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,12 +116,6 @@ export function activate(context: vscode.ExtensionContext) {
 		context.globalState.update("codesphere.currentWorkspace", workspaceId);
 
 		vscode.commands.executeCommand('setContext', 'codesphere.currentWorkspace', workspaceId);
-
-
-		if (workspaceId !== "") {
-			const pwdUri = vscode.Uri.parse('home/user/app');
-			vscode.commands.executeCommand('vscode.openFolder', pwdUri);
-		}
 	});
 
 	exec (gitBashEmail, (error, stdout, stderr) => {


### PR DESCRIPTION
Resolved this error which occured in the VS Code extention for Windows (Windows 11):
![image](https://github.com/user-attachments/assets/8ad95f93-e3b7-4ff0-b980-821dca6d3e45)